### PR TITLE
Update InvitationListener.php

### DIFF
--- a/src/Listeners/InvitationListener.php
+++ b/src/Listeners/InvitationListener.php
@@ -4,9 +4,9 @@ namespace ZiNETHQ\SparkInvite\Listeners;
 
 abstract class InvitationListener
 {
-    public function handle($event, $data)
+    public function handle($event, $invitation)
     {
-        return call_user_func(array($this, $data['event']), $data['invitation']);
+        return call_user_func(array($this, $event), $invitation);
     }
 
     abstract public function invite($invitation);


### PR DESCRIPTION
## Description
Reverting changes - We have been testing on our Laravel 5.3 product and this is correct. Checking the data sent through to each argument confirm that the $event and $data (renamed back to $invitation) were correct. There are no release notes indicating listeners have changed in Laravel 5.4 - if there is and this causes a problem then we can look at how to overcome it, but the project must work in 5.3.

## Motivation and Context
To get it working in one of ZiNETHQ's main products.

## How Has This Been Tested?
On local Dev system

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

This is technically not breaking as it's reverted back to a previous state when it was working, but it is if there really has been a breaking change in Laravel 5.4 etc.

@drjonnicholson, please check that the suggested code works on our project before accepting external code changes!

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.